### PR TITLE
delete unnecessary migration files

### DIFF
--- a/db/migrate/20190929063425_remove_uid_from_declares.rb
+++ b/db/migrate/20190929063425_remove_uid_from_declares.rb
@@ -1,5 +1,0 @@
-class RemoveUidFromDeclares < ActiveRecord::Migration[5.2]
-  def change
-    remove_column :declares, :uid, :string
-  end
-end

--- a/db/migrate/20190929064920_destroy_declare.rb
+++ b/db/migrate/20190929064920_destroy_declare.rb
@@ -1,5 +1,0 @@
-class DestroyDeclare < ActiveRecord::Migration[5.2]
-  def change
-    drop_table :declares
-  end
-end


### PR DESCRIPTION
Deleted migration files about declares table which drops the table or a column.